### PR TITLE
docs: update Header link and reorganize sidebar structure

### DIFF
--- a/PropertyBitPackDocs/Pages/Shared/Header.cshtml
+++ b/PropertyBitPackDocs/Pages/Shared/Header.cshtml
@@ -1,7 +1,7 @@
 @{
     var menuItems = new (string Href, string Text)[]
     {
-        ("/", "To Users"),
+        ("./", "To Users"),
         ("to_developers/", "To Developers"),
     };
 }

--- a/PropertyBitPackDocs/_pages/sidebar.json
+++ b/PropertyBitPackDocs/_pages/sidebar.json
@@ -1,43 +1,37 @@
 [
   {
     "text": "Introduction",
-    "link": "PropertyBitPack/",
+    "link": "PropertyBitPack/"
+  },
+  {
+    "text": "BitFieldAttribute",
+    "link": "PropertyBitPack/bit-field-attribute",
     "children": [
       {
-        "text": "BitFieldAttribute",
-        "link": "PropertyBitPack/bit-field-attribute",
-        "children": [
-          {
-            "text": "BitFieldAttribute",
-            "link": "PropertyBitPack/bit-field-attribute"
-          },
-          {
-            "text": "Custom Field Name",
-            "link": "PropertyBitPack/bit-field-attribute-custom-field-name"
-          },
-          {
-            "text": "Reference To Existing Field",
-            "link": "PropertyBitPack/bit-field-attribute-reference-to-existing-field"
-          },
-          {
-            "text": "Custom Bit's Size",
-            "link": "PropertyBitPack/bit-field-attribute-custom-bits-size"
-          }
-        ]
+        "text": "Custom Field Name",
+        "link": "PropertyBitPack/bit-field-attribute-custom-field-name"
       },
       {
-        "text": "ExtendedBitFieldAttribute",
-        "link": "PropertyBitPack/extended-bit-field-attribute"
+        "text": "Reference To Existing Field",
+        "link": "PropertyBitPack/bit-field-attribute-reference-to-existing-field"
       },
       {
-        "text": "ReadOnlyBitFieldAttribute",
-        "link": "PropertyBitPack/read-only-bit-field-attribute"
-      },
-      {
-        "text": "ReadOnlyExtendedBitField",
-        "link": "PropertyBitPack/read-only-extended-bit-field-attribute"
+        "text": "Custom Bit's Size",
+        "link": "PropertyBitPack/bit-field-attribute-custom-bits-size"
       }
     ]
+  },
+  {
+    "text": "ExtendedBitFieldAttribute",
+    "link": "PropertyBitPack/extended-bit-field-attribute"
+  },
+  {
+    "text": "ReadOnlyBitFieldAttribute",
+    "link": "PropertyBitPack/read-only-bit-field-attribute"
+  },
+  {
+    "text": "ReadOnlyExtendedBitField",
+    "link": "PropertyBitPack/read-only-extended-bit-field-attribute"
   },
   {
     "text": "Diagnostic",


### PR DESCRIPTION
## What does the pull request do?  
This pull request improves navigation by updating the "To Users" link in `Header.cshtml` and reorganizing the sidebar structure for better clarity.  

## What is the current behavior?  
- The "To Users" link in `Header.cshtml` uses an absolute path instead of a relative one.  
- The sidebar structure is nested inconsistently, making navigation less intuitive.  

## What is the updated/expected behavior with this PR?  
- **Header Update**:  
  - Changed "To Users" link to use a **relative path** for better flexibility.  

- **Sidebar Improvements**:  
  - Updated the **"Introduction"** link to include a trailing slash.  
  - **Reorganized "BitFieldAttribute"** as a parent item with direct children.  
  - Flattened `"BitFieldAttribute"` sub-items to improve accessibility.  
  - Added **new top-level sections** for:  
    - `"ExtendedBitFieldAttribute"`  
    - `"ReadOnlyBitFieldAttribute"`  
    - `"ReadOnlyExtendedBitField"`  

## How was the solution implemented?  
- Updated `Header.cshtml` to use a relative link for `"To Users"`.  
- Modified `sidebar.json` to reflect the new navigation structure.  

## Checklist  

- [ ] Added unit tests (if possible)?  
- [ ] Updated XML documentation where applicable?  
- [ ] Followed the coding style and formatting rules?  
- [ ] All CI checks passed?  

## Breaking changes  
None.  

## Obsoletions / Deprecations  
None.  

## Fixed issues  
None.  
