### PR TITLE
docs: fix markdown headers and navigation links

### DIFF
--- a/PropertyBitPackDocs/_pages/bit-field-attribute-custom-bits-size.md
+++ b/PropertyBitPackDocs/_pages/bit-field-attribute-custom-bits-size.md
@@ -2,8 +2,6 @@
 title: Custom Bit's Size
 ---
 
-# Custom Bit's Size
-
 By default, **BitFieldAttribute** automatically determines the number of bits based on the property type. However, you can **explicitly specify the number of bits** using the `BitsCount` parameter.
 
 ## **Defining Custom Bit Sizes**
@@ -163,4 +161,4 @@ Error PRBITS001: The BitsCount for property 'LargeData' must be a positive integ
 ✔ **Compilation error (`PRBITS001`)** if exceeding 64 bits without splitting.
 
 
-📖 **[Next: ReadOnly BitFields →](PropertyBitPack/extended-bit-field-attribute)**
+📖 **[Next: ReadOnly BitFields →](extended-bit-field-attribute)**

--- a/PropertyBitPackDocs/_pages/bit-field-attribute-custom-field-name.md
+++ b/PropertyBitPackDocs/_pages/bit-field-attribute-custom-field-name.md
@@ -2,8 +2,6 @@
 title: Custom Field Name
 ---
 
-# Custom Field Name
-
 By default, `BitFieldAttribute` **automatically** assigns a private backing field to store multiple bit-packed properties. However, you can explicitly **specify a field name** to group properties into a specific field.
 
 ## **Defining a Custom Field Name**
@@ -119,4 +117,4 @@ public partial bool Flag3 { get; set; }
 ✔ **Combine multiple properties** into the same storage.  
 ✔ ❌ **No automatic field splitting beyond 64 bits** → You must manually create a second field.  
 
-📖 **[Next: Reference to Existing Field →](PropertyBitPack/bit-field-attribute-reference-to-existing-field)**
+📖 **[Next: Reference to Existing Field →](bit-field-attribute-reference-to-existing-field)**

--- a/PropertyBitPackDocs/_pages/bit-field-attribute-reference-to-existing-field.md
+++ b/PropertyBitPackDocs/_pages/bit-field-attribute-reference-to-existing-field.md
@@ -2,8 +2,6 @@
 title: Reference to Existing Field
 ---
 
-# Reference to Existing Field
-
 Instead of allowing `BitFieldAttribute` to automatically generate a backing field, you can **manually reference an existing field** by specifying its name using `nameof`. This is useful when working with predefined data structures or when controlling memory layout.
 
 ## **Referencing an Existing Field**
@@ -101,4 +99,4 @@ private long _data; // Now supports 64 bits
 ✔ **Ensure total bit count stays within field size limits**.  
 ✔ ❌ **Exceeding the field’s capacity results in a compiler error (`PRBITS012`).**
 
-📖 **[Next: Custom Bits Size →](PropertyBitPack/bit-field-attribute-custom-bits-size)**
+📖 **[Next: Custom Bits Size →](bit-field-attribute-custom-bits-size)**

--- a/PropertyBitPackDocs/_pages/bit-field-attribute.md
+++ b/PropertyBitPackDocs/_pages/bit-field-attribute.md
@@ -2,8 +2,6 @@
 title: BitFieldAttribute
 ---
 
-# BitFieldAttribute
-
 `BitFieldAttribute` allows multiple properties to be **packed into a single numeric field**, significantly reducing memory usage. It is useful in **game development, serialization, networking, and embedded systems**.
 
 ## Basic Usage
@@ -202,4 +200,4 @@ public partial class Example
 ✔ **Flexible Accessors** – Use `set`, `init`, or remove the setter entirely.  
 ✔ **Supports Modifiers** – Customize setters with `private`, `internal`, etc.  
 
-📖 **[Next: Custom Field Name →](PropertyBitPack/bit-field-attribute-custom-field-name)**
+📖 **[Next: Custom Field Name →](bit-field-attribute-custom-field-name)**

--- a/PropertyBitPackDocs/_pages/extended-bit-field-attribute.md
+++ b/PropertyBitPackDocs/_pages/extended-bit-field-attribute.md
@@ -2,8 +2,6 @@
 title: ExtendedBitFieldAttribute
 ---
 
-# ExtendedBitFieldAttribute
-
 `ExtendedBitFieldAttribute` extends the functionality of `BitFieldAttribute`. It provides the same features as `BitFieldAttribute` but **adds support for handling values that exceed the allocated bit size**.
 
 ## **What is ExtendedBitFieldAttribute?**
@@ -105,4 +103,4 @@ If `ShortValue` exceeds **2^6 = 64**, the getter **returns `FullValue` instead**
 ⚠ **If `GetterLargeSizeValueName` is missing**, the generator **will produce a compilation error**.  
 ⚠ **The getter method must return the same type** as the bit-packed property.  
 
-📖 **[Next: ReadOnly BitFields →](PropertyBitPack/read-only-bit-field-attribute)**
+📖 **[Next: ReadOnly BitFields →](read-only-bit-field-attribute)**

--- a/PropertyBitPackDocs/_pages/read-only-bit-field-attribute.md
+++ b/PropertyBitPackDocs/_pages/read-only-bit-field-attribute.md
@@ -2,8 +2,6 @@
 title: ReadOnlyBitFieldAttribute
 ---
 
-# ReadOnlyBitFieldAttribute
-
 `ReadOnlyBitFieldAttribute` extends the functionality of `BitFieldAttribute`. It provides the **same bit-packing features** while also **generating constructors** for initializing read-only bit-packed properties.
 
 ## **What is ReadOnlyBitFieldAttribute?**
@@ -176,4 +174,4 @@ public partial int Value2 { get; init; } // ✅ Init-only setter
 ⚠ If a property **exceeds the allocated bit size**, compilation will **fail with an error**.  
 ⚠ **By default, the constructor is `private`**. Use `ConstructorAccessModifier` to change visibility.
 
-📖 **[Next: ReadOnlyExtendedBitField →](PropertyBitPack/read-only-extended-bit-field-attribute)**
+📖 **[Next: ReadOnlyExtendedBitField →](read-only-extended-bit-field-attribute)**

--- a/PropertyBitPackDocs/_pages/read-only-extended-bit-field-attribute.md
+++ b/PropertyBitPackDocs/_pages/read-only-extended-bit-field-attribute.md
@@ -2,8 +2,6 @@
 title: ReadOnlyExtendedBitFieldAttribute
 ---
 
-# ReadOnlyExtendedBitFieldAttribute
-
 `ReadOnlyExtendedBitFieldAttribute` combines the functionality of **`ReadOnlyBitFieldAttribute`** and **`ExtendedBitFieldAttribute`**. It provides **bit-packing for read-only properties** while allowing values **larger than the allocated bit size** by redirecting to an external getter.
 
 ## **What is ReadOnlyExtendedBitFieldAttribute?**


### PR DESCRIPTION
## What does the pull request do?  
This pull request improves markdown formatting by fixing title headers and correcting navigation links in multiple documentation files.  

## What is the current behavior?  
- Some markdown files contain redundant `#` characters in headers.  
- Navigation links at the bottom of files include the unnecessary `PropertyBitPack/` prefix, causing incorrect relative paths.  
- Titles in certain markdown files are inconsistent.  

## What is the updated/expected behavior with this PR?  
- **Header formatting**:  
  - Removed extra `#` characters from titles for cleaner markdown.  
- **Navigation fixes**:  
  - Corrected navigation links by removing the `PropertyBitPack/` prefix.  
- **Title consistency**:  
  - Standardized titles across markdown files for clarity.  

## How was the solution implemented?  
- Manually reviewed and updated markdown headers.  
- Adjusted navigation links to use correct relative paths.  
- Renamed and reformatted markdown titles for consistency.  

## Checklist  

- [ ] Added unit tests (if possible)?  
- [ ] Updated XML documentation where applicable?  
- [ ] Followed the coding style and formatting rules?  
- [ ] All CI checks passed?  

## Breaking changes  
None.  

## Obsoletions / Deprecations  
None.  

## Fixed issues  
None.  
