### PR TITLE
Feature/static bitwise helpers

### DIFF
--- a/PropertyBitPack.Tests/BitFieldUtilsTest.cs
+++ b/PropertyBitPack.Tests/BitFieldUtilsTest.cs
@@ -19,4 +19,328 @@ public class BitFieldUtilsTest
 
         Assert.True(BitFieldUtils.GetBoolValue(ref byteField, byteFieldIndex));
     }
+
+    [Fact]
+    public void TestByteValue()
+    {
+        byte field = 0;
+        var range = 2..5; // 3 bits
+        byte valueToSet = 0b101; // 5
+        BitFieldUtils.SetByteValue(ref field, range, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetByteValue(ref field, range));
+    }
+
+    [Fact]
+    public void TestSByteValue()
+    {
+        sbyte field = 0;
+        var range = 1..4; // 3 bits
+        sbyte valueToSet = 0b011; // 3
+        BitFieldUtils.SetSByteValue(ref field, range, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetSByteValue(ref field, range));
+    }
+
+    [Fact]
+    public void TestShortValue()
+    {
+        short field = 0;
+        var range = 5..12; // 7 bits
+        short valueToSet = 0b1010101; // 85
+        BitFieldUtils.SetShortValue(ref field, range, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetShortValue(ref field, range));
+    }
+
+    [Fact]
+    public void TestUShortValue()
+    {
+        ushort field = 0;
+        var range = 3..10; // 7 bits
+        ushort valueToSet = 0b1101010; // 106
+        BitFieldUtils.SetUShortValue(ref field, range, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetUShortValue(ref field, range));
+    }
+
+    [Fact]
+    public void TestIntValue()
+    {
+        var field = 0;
+        var range = 10..20; // 10 bits
+        var valueToSet = 0b1010101010; // 682
+        BitFieldUtils.SetIntValue(ref field, range, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetIntValue(ref field, range));
+    }
+
+    [Fact]
+    public void TestUIntValue()
+    {
+        uint field = 0;
+        var range = 5..15; // 10 bits
+        uint valueToSet = 0b1110011100; // Some 10-bit value
+        BitFieldUtils.SetUIntValue(ref field, range, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetUIntValue(ref field, range));
+    }
+
+    [Fact]
+    public void TestLongValue()
+    {
+        long field = 0;
+        var range = 20..40; // 20 bits
+        long valueToSet = 0b10101010101010101010; // 20-bit value
+        BitFieldUtils.SetLongValue(ref field, range, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetLongValue(ref field, range));
+    }
+
+    [Fact]
+    public void TestULongValue()
+    {
+        ulong field = 0;
+        var range = 30..50; // 20 bits
+        var valueToSet = 0b10101010101010101010UL; // 20-bit value
+        BitFieldUtils.SetULongValue(ref field, range, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetULongValue(ref field, range));
+    }
+
+    [Fact]
+    public void TestByteMultipleValues()
+    {
+        // Partition 8 bits: 0..3 (3 bits), 3..6 (3 bits), 6..8 (2 bits)
+        byte field = 0;
+        byte value1 = 0b101; // 5 (3 bits)
+        byte value2 = 0b011; // 3 (3 bits)
+        byte value3 = 0b10;  // 2 (2 bits)
+
+        BitFieldUtils.SetByteValue(ref field, 0..3, value1);
+        BitFieldUtils.SetByteValue(ref field, 3..6, value2);
+        BitFieldUtils.SetByteValue(ref field, 6..8, value3);
+
+        Assert.Equal(value1, BitFieldUtils.GetByteValue(ref field, 0..3));
+        Assert.Equal(value2, BitFieldUtils.GetByteValue(ref field, 3..6));
+        Assert.Equal(value3, BitFieldUtils.GetByteValue(ref field, 6..8));
+    }
+
+    [Fact]
+    public void TestSByteMultipleValues()
+    {
+        // Partition 8 bits: 0..3, 3..6, 6..8
+        sbyte field = 0;
+        sbyte value1 = 0b101; // 5
+        sbyte value2 = 0b011; // 3
+        sbyte value3 = 0b10;  // 2
+
+        BitFieldUtils.SetSByteValue(ref field, 0..3, value1);
+        BitFieldUtils.SetSByteValue(ref field, 3..6, value2);
+        BitFieldUtils.SetSByteValue(ref field, 6..8, value3);
+
+        Assert.Equal(value1, BitFieldUtils.GetSByteValue(ref field, 0..3));
+        Assert.Equal(value2, BitFieldUtils.GetSByteValue(ref field, 3..6));
+        Assert.Equal(value3, BitFieldUtils.GetSByteValue(ref field, 6..8));
+    }
+
+    [Fact]
+    public void TestShortMultipleValues()
+    {
+        // Partition 16 bits: 0..5 (5 bits), 5..11 (6 bits), 11..16 (5 bits)
+        short field = 0;
+        short value1 = 0b10101;  // 21 (max 31)
+        short value2 = 0b110011; // 51 (max 63)
+        short value3 = 0b10110;  // 22 (max 31)
+
+        BitFieldUtils.SetShortValue(ref field, 0..5, value1);
+        BitFieldUtils.SetShortValue(ref field, 5..11, value2);
+        BitFieldUtils.SetShortValue(ref field, 11..16, value3);
+
+        Assert.Equal(value1, BitFieldUtils.GetShortValue(ref field, 0..5));
+        Assert.Equal(value2, BitFieldUtils.GetShortValue(ref field, 5..11));
+        Assert.Equal(value3, BitFieldUtils.GetShortValue(ref field, 11..16));
+    }
+
+    [Fact]
+    public void TestUShortMultipleValues()
+    {
+        // Partition 16 bits: 0..5, 5..11, 11..16
+        ushort field = 0;
+        ushort value1 = 0b10101;  // 21
+        ushort value2 = 0b110011; // 51
+        ushort value3 = 0b10110;  // 22
+
+        BitFieldUtils.SetUShortValue(ref field, 0..5, value1);
+        BitFieldUtils.SetUShortValue(ref field, 5..11, value2);
+        BitFieldUtils.SetUShortValue(ref field, 11..16, value3);
+
+        Assert.Equal(value1, BitFieldUtils.GetUShortValue(ref field, 0..5));
+        Assert.Equal(value2, BitFieldUtils.GetUShortValue(ref field, 5..11));
+        Assert.Equal(value3, BitFieldUtils.GetUShortValue(ref field, 11..16));
+    }
+
+    [Fact]
+    public void TestIntMultipleValues()
+    {
+        // Partition 32 bits: 0..10 (10 bits), 10..22 (12 bits), 22..32 (10 bits)
+        var field = 0;
+        var value1 = 0x1AB; // 427, fits in 10 bits (max 1023)
+        var value2 = 0xABC; // 2748, fits in 12 bits (max 4095)
+        var value3 = 0x2CD; // 717, fits in 10 bits
+
+        BitFieldUtils.SetIntValue(ref field, 0..10, value1);
+        BitFieldUtils.SetIntValue(ref field, 10..22, value2);
+        BitFieldUtils.SetIntValue(ref field, 22..32, value3);
+
+        Assert.Equal(value1, BitFieldUtils.GetIntValue(ref field, 0..10));
+        Assert.Equal(value2, BitFieldUtils.GetIntValue(ref field, 10..22));
+        Assert.Equal(value3, BitFieldUtils.GetIntValue(ref field, 22..32));
+    }
+
+    [Fact]
+    public void TestUIntMultipleValues()
+    {
+        // Partition 32 bits: 0..10, 10..22, 22..32
+        uint field = 0;
+        uint value1 = 0x1AB; // 427
+        uint value2 = 0xABC; // 2748
+        uint value3 = 0x2CD; // 717
+
+        BitFieldUtils.SetUIntValue(ref field, 0..10, value1);
+        BitFieldUtils.SetUIntValue(ref field, 10..22, value2);
+        BitFieldUtils.SetUIntValue(ref field, 22..32, value3);
+
+        Assert.Equal(value1, BitFieldUtils.GetUIntValue(ref field, 0..10));
+        Assert.Equal(value2, BitFieldUtils.GetUIntValue(ref field, 10..22));
+        Assert.Equal(value3, BitFieldUtils.GetUIntValue(ref field, 22..32));
+    }
+
+    [Fact]
+    public void TestLongMultipleValues()
+    {
+        // Partition 64 bits: 0..20 (20 bits), 20..45 (25 bits), 45..64 (19 bits)
+        long field = 0;
+        long value1 = 123456;  // fits in 20 bits (max 1,048,575)
+        long value2 = 9876543; // fits in 25 bits (max 33,554,431)
+        long value3 = 345678;  // fits in 19 bits (max 524,287)
+
+        BitFieldUtils.SetLongValue(ref field, 0..20, value1);
+        BitFieldUtils.SetLongValue(ref field, 20..45, value2);
+        BitFieldUtils.SetLongValue(ref field, 45..64, value3);
+
+        Assert.Equal(value1, BitFieldUtils.GetLongValue(ref field, 0..20));
+        Assert.Equal(value2, BitFieldUtils.GetLongValue(ref field, 20..45));
+        Assert.Equal(value3, BitFieldUtils.GetLongValue(ref field, 45..64));
+    }
+
+    [Fact]
+    public void TestULongMultipleValues()
+    {
+        // Partition 64 bits: 0..20, 20..45, 45..64
+        ulong field = 0;
+        var value1 = 123456UL;  // fits in 20 bits
+        var value2 = 9876543UL; // fits in 25 bits
+        var value3 = 345678UL;  // fits in 19 bits
+
+        BitFieldUtils.SetULongValue(ref field, 0..20, value1);
+        BitFieldUtils.SetULongValue(ref field, 20..45, value2);
+        BitFieldUtils.SetULongValue(ref field, 45..64, value3);
+
+        Assert.Equal(value1, BitFieldUtils.GetULongValue(ref field, 0..20));
+        Assert.Equal(value2, BitFieldUtils.GetULongValue(ref field, 20..45));
+        Assert.Equal(value3, BitFieldUtils.GetULongValue(ref field, 45..64));
+    }
+
+    [Fact]
+    public void TestByteValue_RangeOperators_WithCaret()
+    {
+        byte field = 0;
+        // ^3..^1: For an 8-bit field, ^3 means 8-3 = 5 and ^1 means 8-1 = 7, so length = 2.
+        byte valueToSet = 0b10; // value = 2 fits in 2 bits
+        BitFieldUtils.SetByteValue(ref field, ^3..^1, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetByteValue(ref field, ^3..^1));
+    }
+
+    [Fact]
+    public void TestByteValue_RangeOperators_StartOnly()
+    {
+        byte field = 0;
+        // 4.. means from index 4 to end (4 bits: indices 4-7)
+        byte valueToSet = 0b1010; // 10 fits in 4 bits
+        BitFieldUtils.SetByteValue(ref field, 4.., valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetByteValue(ref field, 4..));
+    }
+
+    [Fact]
+    public void TestByteValue_RangeOperators_EndOnly()
+    {
+        byte field = 0;
+        // ..3 means from index 0 to 3 (3 bits)
+        byte valueToSet = 0b110; // 6 fits in 3 bits
+        BitFieldUtils.SetByteValue(ref field, ..3, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetByteValue(ref field, ..3));
+    }
+
+    [Fact]
+    public void TestSByteValue_RangeOperators_WithCaret()
+    {
+        sbyte field = 0;
+        // Using ^ operators on an 8-bit sbyte.
+        sbyte valueToSet = 0b010; // 2 fits in 2 bits.
+        BitFieldUtils.SetSByteValue(ref field, ^3..^1, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetSByteValue(ref field, ^3..^1));
+    }
+
+    [Fact]
+    public void TestShortValue_RangeOperators_WithMixedRange()
+    {
+        short field = 0;
+        // For a 16-bit short, use 5..^3. ^3 means 16-3 = 13 so length = 13-5 = 8 bits.
+        short valueToSet = 0x5A; // 90 decimal, fits in 8 bits.
+        BitFieldUtils.SetShortValue(ref field, 5..^3, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetShortValue(ref field, 5..^3));
+    }
+
+    [Fact]
+    public void TestUShortValue_RangeOperators_WithMixedRange()
+    {
+        ushort field = 0;
+        // For a 16-bit ushort, use 4..^4. ^4 means 16-4 = 12 so length = 12-4 = 8 bits.
+        ushort valueToSet = 0xA5; // 165 decimal.
+        BitFieldUtils.SetUShortValue(ref field, 4..^4, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetUShortValue(ref field, 4..^4));
+    }
+
+    [Fact]
+    public void TestIntValue_RangeOperators_WithCaret()
+    {
+        var field = 0;
+        // For a 32-bit int, use ^12..^4: ^12 means 32-12 = 20, ^4 means 32-4 = 28 so length = 8 bits.
+        var valueToSet = 0xAB; // 171 decimal.
+        BitFieldUtils.SetIntValue(ref field, ^12..^4, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetIntValue(ref field, ^12..^4));
+    }
+
+    [Fact]
+    public void TestUIntValue_RangeOperators_WithMixedRange()
+    {
+        uint field = 0;
+        // For a 32-bit uint, use 10..^10: ^10 means 32-10 = 22 so length = 22-10 = 12 bits.
+        uint valueToSet = 0xABC; // 2748 decimal.
+        BitFieldUtils.SetUIntValue(ref field, 10..^10, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetUIntValue(ref field, 10..^10));
+    }
+
+    [Fact]
+    public void TestLongValue_RangeOperators_WithMixedRange()
+    {
+        long field = 0;
+        // For a 64-bit long, use 20..^20: ^20 means 64-20 = 44, so length = 44-20 = 24 bits.
+        long valueToSet = 0xABCDE; // 703710 decimal, fits in 24 bits.
+        BitFieldUtils.SetLongValue(ref field, 20..^20, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetLongValue(ref field, 20..^20));
+    }
+
+    [Fact]
+    public void TestULongValue_RangeOperators_WithCaret()
+    {
+        ulong field = 0;
+        // For a 64-bit ulong, use ..^32: from start to index 64-32 = 32 (length = 32 bits)
+        ulong valueToSet = 0xDEADBEEF; // fits in 32 bits.
+        BitFieldUtils.SetULongValue(ref field, ..^32, valueToSet);
+        Assert.Equal(valueToSet, BitFieldUtils.GetULongValue(ref field, ..^32));
+    }
 }

--- a/PropertyBitPack.Tests/BitFieldUtilsTest.cs
+++ b/PropertyBitPack.Tests/BitFieldUtilsTest.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PropertyBitPack.Tests;
+
+public class BitFieldUtilsTest
+{
+    [Fact]
+    public void TestBoolValue()
+    {
+        var byteField = (byte)0b0000_0000;
+        var byteFieldIndex = Random.Shared.Next(0, 8);
+
+        BitFieldUtils.SetBoolValue(ref byteField, byteFieldIndex, true);
+
+
+        Assert.True(BitFieldUtils.GetBoolValue(ref byteField, byteFieldIndex));
+    }
+}

--- a/PropertyBitPack/BitFieldUtils.Bool.cs
+++ b/PropertyBitPack/BitFieldUtils.Bool.cs
@@ -1,0 +1,230 @@
+﻿using CommunityToolkit.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PropertyBitPack;
+
+public static partial class BitFieldUtils
+{
+    public static bool GetBoolValue(ref readonly byte field, int bitIndex)
+    {
+        if (bitIndex < 0 || bitIndex > 7)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 7.");
+        }
+
+        return (field & (1 << bitIndex)) != 0;
+    }
+
+    public static void SetBoolValue(ref byte field, int bitIndex, bool value)
+    {
+        if (bitIndex < 0 || bitIndex > 7)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 7.");
+        }
+
+        if (value)
+        {
+            field = (byte)(field | (1 << bitIndex));
+        }
+        else
+        {
+            field = (byte)(field & ~(1 << bitIndex));
+        }
+    }
+
+
+    public static bool GetBoolValue(ref readonly sbyte field, int bitIndex)
+    {
+        if (bitIndex < 0 || bitIndex > 7)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 7.");
+        }
+
+        return (field & (1 << bitIndex)) != 0;
+    }
+
+    public static void SetBoolValue(ref sbyte field, int bitIndex, bool value)
+    {
+        if (bitIndex < 0 || bitIndex > 7)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 7.");
+        }
+
+        var mask = (byte)(1 << bitIndex); 
+
+        if (value)
+        {
+            field = (sbyte)(field | (sbyte)mask); 
+        }
+        else
+        {
+            field = (sbyte)(field & (sbyte)~mask);
+        }
+    }
+
+    public static bool GetBoolValue(ref readonly short field, int bitIndex)
+    {
+        if (bitIndex < 0 || bitIndex > 15)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 15.");
+        }
+
+        return (field & (1 << bitIndex)) != 0;
+    }
+
+    public static void SetBoolValue(ref short field, int bitIndex, bool value)
+    {
+        if (bitIndex < 0 || bitIndex > 15)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 15.");
+        }
+
+        if (value)
+        {
+            field |= (short)(1 << bitIndex);
+        }
+        else
+        {
+            field &= (short)~(1 << bitIndex);
+        }
+    }
+
+    public static bool GetBoolValue(ref readonly ushort field, int bitIndex)
+    {
+        if (bitIndex < 0 || bitIndex > 15)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 15.");
+        }
+
+        return (field & (1 << bitIndex)) != 0;
+    }
+
+    public static void SetBoolValue(ref ushort field, int bitIndex, bool value)
+    {
+        if (bitIndex < 0 || bitIndex > 15)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 15.");
+        }
+
+        if (value)
+        {
+            field |= (ushort)(1 << bitIndex);
+        }
+        else
+        {
+            field &= (ushort)~(1 << bitIndex);
+        }
+    }
+
+    public static bool GetBoolValue(ref readonly int field, int bitIndex)
+    {
+        if (bitIndex < 0 || bitIndex > 31)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 31.");
+        }
+
+        return (field & (1 << bitIndex)) != 0;
+    }
+
+    public static void SetBoolValue(ref int field, int bitIndex, bool value)
+    {
+        if (bitIndex < 0 || bitIndex > 31)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 31.");
+        }
+
+        if (value)
+        {
+            field |= (1 << bitIndex);
+        }
+        else
+        {
+            field &= ~(1 << bitIndex);
+        }
+    }
+
+    public static bool GetBoolValue(ref readonly uint field, int bitIndex)
+    {
+        if (bitIndex < 0 || bitIndex > 31)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 31.");
+        }
+
+        return (field & (1U << bitIndex)) != 0;
+    }
+
+    public static void SetBoolValue(ref uint field, int bitIndex, bool value)
+    {
+        if (bitIndex < 0 || bitIndex > 31)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 31.");
+        }
+
+        if (value)
+        {
+            field |= (1U << bitIndex);
+        }
+        else
+        {
+            field &= ~(1U << bitIndex);
+        }
+    }
+
+    public static bool GetBoolValue(ref readonly long field, int bitIndex)
+    {
+        if (bitIndex < 0 || bitIndex > 63)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 63.");
+        }
+
+        return (field & (1L << bitIndex)) != 0;
+    }
+
+    public static void SetBoolValue(ref long field, int bitIndex, bool value)
+    {
+        if (bitIndex < 0 || bitIndex > 63)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 63.");
+        }
+
+        if (value)
+        {
+            field |= (1L << bitIndex);
+        }
+        else
+        {
+            field &= ~(1L << bitIndex);
+        }
+    }
+
+    public static bool GetBoolValue(ref readonly ulong field, int bitIndex)
+    {
+        if (bitIndex < 0 || bitIndex > 63)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 63.");
+        }
+
+        return (field & (1UL << bitIndex)) != 0;
+    }
+
+    public static void SetBoolValue(ref ulong field, int bitIndex, bool value)
+    {
+        if (bitIndex < 0 || bitIndex > 63)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bitIndex), bitIndex, "The bit index must be between 0 and 63.");
+        }
+
+        if (value)
+        {
+            field |= (1UL << bitIndex);
+        }
+        else
+        {
+            field &= ~(1UL << bitIndex);
+        }
+    }
+}

--- a/PropertyBitPack/BitFieldUtils.Byte.cs
+++ b/PropertyBitPack/BitFieldUtils.Byte.cs
@@ -1,0 +1,251 @@
+﻿using CommunityToolkit.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PropertyBitPack;
+public static partial class BitFieldUtils
+{
+    public static byte GetByteValue(ref readonly byte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8); 
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (byte)((1 << length) - 1); 
+
+        return (byte)((field >> start) & mask); 
+    }
+
+    public static void SetByteValue(ref byte field, Range range, byte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8); 
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (byte)((1 << length) - 1); 
+        var clampedValue = (byte)(value & mask); 
+
+        field &= (byte)~(mask << start);
+
+        field |= (byte)(clampedValue << start);
+    }
+
+    public static byte GetByteValue(ref readonly sbyte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (byte)((1 << length) - 1);
+
+        return (byte)((field >> start) & mask);
+    }
+
+    public static void SetByteValue(ref sbyte field, Range range, byte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (byte)((1 << length) - 1);
+        var clampedValue = (byte)(value & mask);
+
+        field &= (sbyte)~(mask << start);
+        field |= (sbyte)(clampedValue << start);
+    }
+
+    public static byte GetByteValue(ref readonly short field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (byte)((1 << length) - 1);
+
+        return (byte)((field >> start) & mask);
+    }
+
+    public static void SetByteValue(ref short field, Range range, byte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (byte)((1 << length) - 1);
+        var clampedValue = (byte)(value & mask);
+
+        field &= (short)~(mask << start);
+        field |= (short)(clampedValue << start);
+    }
+
+    public static byte GetByteValue(ref readonly ushort field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (byte)((1 << length) - 1);
+
+        return (byte)((field >> start) & mask);
+    }
+
+    public static void SetByteValue(ref ushort field, Range range, byte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (byte)((1 << length) - 1);
+        var clampedValue = (byte)(value & mask);
+
+        field &= (ushort)~(mask << start);
+        field |= (ushort)(clampedValue << start);
+    }
+
+    public static byte GetByteValue(ref readonly int field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (byte)((1 << length) - 1);
+
+        return (byte)((field >> start) & mask);
+    }
+
+    public static void SetByteValue(ref int field, Range range, byte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (byte)((1 << length) - 1);
+        var clampedValue = (byte)(value & mask);
+
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static byte GetByteValue(ref readonly uint field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (1U << length) - 1; 
+
+        return (byte)((field >> start) & mask);
+    }
+
+    public static void SetByteValue(ref uint field, Range range, byte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (1U << length) - 1; 
+        var clampedValue = value & mask;
+
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static byte GetByteValue(ref readonly long field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (byte)((1 << length) - 1);
+
+        return (byte)((field >> start) & mask);
+    }
+
+    public static void SetByteValue(ref long field, Range range, byte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (1L << length) - 1;
+        var clampedValue = value & mask; 
+
+        field &= ~(mask << start);
+        field |= (clampedValue << start); 
+    }
+
+    public static byte GetByteValue(ref readonly ulong field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = ((1UL << length) - 1); 
+
+        return (byte)((field >> start) & mask);
+    }
+
+    public static void SetByteValue(ref ulong field, Range range, byte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (1UL << length) - 1; 
+        var clampedValue = value & mask;
+
+        field &= ~(mask << start); 
+        field |= (clampedValue << start);
+    }
+}

--- a/PropertyBitPack/BitFieldUtils.Int.cs
+++ b/PropertyBitPack/BitFieldUtils.Int.cs
@@ -1,0 +1,203 @@
+﻿using CommunityToolkit.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PropertyBitPack;
+
+public static partial class BitFieldUtils
+{
+    public static int GetIntValue(ref readonly byte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (int)(((long)1 << length) - 1);
+        return (int)((field >> start) & mask);
+    }
+
+    public static void SetIntValue(ref byte field, Range range, int value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (byte)((1 << length) - 1);
+        var clampedValue = value & mask;
+        field &= (byte)~(mask << start);
+        field |= (byte)(clampedValue << start);
+    }
+
+    public static int GetIntValue(ref readonly sbyte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (int)((1 << length) - 1);
+        return (int)((field >> start) & mask);
+    }
+
+    public static void SetIntValue(ref sbyte field, Range range, int value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (sbyte)((1 << length) - 1);
+        var clampedValue = value & mask;
+        field &= (sbyte)~(mask << start);
+        field |= (sbyte)(clampedValue << start);
+    }
+
+    public static int GetIntValue(ref readonly short field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (int)(((long)1 << length) - 1);
+        return (int)((field >> start) & mask);
+    }
+
+    public static void SetIntValue(ref short field, Range range, int value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (short)((1U << length) - 1);
+        var clampedValue = value & mask;
+        field &= (short)~(mask << start);
+        field |= (short)(clampedValue << start);
+    }
+
+    public static int GetIntValue(ref readonly ushort field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (int)((1U << length) - 1);
+        return (int)((field >> start) & mask);
+    }
+
+    public static void SetIntValue(ref ushort field, Range range, int value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (ushort)((1U << length) - 1);
+        var clampedValue = value & mask;
+        field &= (ushort)~(mask << start);
+        field |= (ushort)(clampedValue << start);
+    }
+
+    public static int GetIntValue(ref readonly int field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (int)(((long)1 << length) - 1);
+        return (int)((field >> start) & mask);
+    }
+
+    public static void SetIntValue(ref int field, Range range, int value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1 << length) - 1;
+        var clampedValue = value & mask;
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static int GetIntValue(ref readonly uint field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (uint)((1UL << length) - 1);
+        return (int)((field >> start) & mask);
+    }
+
+    public static void SetIntValue(ref uint field, Range range, int value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1U << length) - 1;
+        var clampedValue = (uint)(value & mask);
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static int GetIntValue(ref readonly long field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (int)(((long)1 << length) - 1);
+        return (int)((field >> start) & mask);
+    }
+
+    public static void SetIntValue(ref long field, Range range, int value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = ((long)1 << length) - 1;
+        var clampedValue = value & (int)mask;
+        field &= ~(mask << start);
+        field |= ((long)clampedValue << start);
+    }
+
+    public static int GetIntValue(ref readonly ulong field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1UL << length) - 1;
+        return (int)((field >> start) & mask);
+    }
+
+    public static void SetIntValue(ref ulong field, Range range, int value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1UL << length) - 1;
+        var clampedValue = (ulong)(value & (int)mask);
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+}

--- a/PropertyBitPack/BitFieldUtils.Long.cs
+++ b/PropertyBitPack/BitFieldUtils.Long.cs
@@ -1,0 +1,203 @@
+﻿using CommunityToolkit.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PropertyBitPack;
+
+public static partial class BitFieldUtils
+{
+    public static long GetLongValue(ref readonly byte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (1L << length) - 1;
+        return (field >> start) & mask;
+    }
+
+    public static void SetLongValue(ref byte field, Range range, long value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (byte)((1 << length) - 1);
+        var clampedValue = value & mask;
+        field &= (byte)~(mask << start);
+        field |= (byte)(clampedValue << start);
+    }
+
+    public static long GetLongValue(ref readonly sbyte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (1L << length) - 1;
+        return (field >> start) & mask;
+    }
+
+    public static void SetLongValue(ref sbyte field, Range range, long value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (sbyte)((1 << length) - 1);
+        var clampedValue = value & mask;
+        field &= (sbyte)~(mask << start);
+        field |= (sbyte)(clampedValue << start);
+    }
+
+    public static long GetLongValue(ref readonly short field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = length == 16 ? ~0L : ((1L << length) - 1);
+        return (field >> start) & mask;
+    }
+
+    public static void SetLongValue(ref short field, Range range, long value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (short)((1U << length) - 1);
+        var clampedValue = value & mask;
+        field &= (short)~(mask << start);
+        field |= (short)(clampedValue << start);
+    }
+
+    public static long GetLongValue(ref readonly ushort field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (ushort)((1U << length) - 1);
+        return (long)((field >> start) & mask);
+    }
+
+    public static void SetLongValue(ref ushort field, Range range, long value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (ushort)((1U << length) - 1);
+        var clampedValue = value & mask;
+        field &= (ushort)~(mask << start);
+        field |= (ushort)(clampedValue << start);
+    }
+
+    public static long GetLongValue(ref readonly int field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (length == 32) ? ~0L : ((1L << length) - 1);
+        return (field >> start) & mask;
+    }
+
+    public static void SetLongValue(ref int field, Range range, long value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1 << length) - 1;
+        var clampedValue = (int)(value & mask);
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static long GetLongValue(ref readonly uint field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1UL << length) - 1;
+        return (long)((field >> start) & mask);
+    }
+
+    public static void SetLongValue(ref uint field, Range range, long value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1U << length) - 1;
+        var clampedValue = value & mask;
+        field &= ~(mask << start);
+        field |= (uint)(clampedValue << start);
+    }
+
+    public static long GetLongValue(ref readonly long field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 64)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 64 bits.");
+        }
+        var mask = (length == 64) ? ~0L : ((1L << length) - 1);
+        return (field >> start) & mask;
+    }
+
+    public static void SetLongValue(ref long field, Range range, long value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 64)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 64 bits.");
+        }
+        var mask = (length == 64) ? ~0L : ((1L << length) - 1);
+        var clampedValue = value & mask;
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static long GetLongValue(ref readonly ulong field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 64)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 64 bits.");
+        }
+        var mask = (length == 64) ? ~0UL : ((1UL << length) - 1);
+        return (long)((field >> start) & mask);
+    }
+
+    public static void SetLongValue(ref ulong field, Range range, long value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 64)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 64 bits.");
+        }
+        var mask = (length == 64) ? ~0UL : ((1UL << length) - 1);
+        var clampedValue = (ulong)(value & (long)mask);
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+}

--- a/PropertyBitPack/BitFieldUtils.SByte.cs
+++ b/PropertyBitPack/BitFieldUtils.SByte.cs
@@ -1,0 +1,251 @@
+﻿using CommunityToolkit.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PropertyBitPack;
+
+public static partial class BitFieldUtils
+{
+    public static sbyte GetSByteValue(ref readonly byte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (sbyte)((1 << length) - 1);
+
+        return (sbyte)((field >> start) & mask);
+    }
+
+    public static void SetSByteValue(ref byte field, Range range, sbyte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (byte)((1 << length) - 1);
+        var clampedValue = (byte)(value & mask);
+
+        field &= (byte)~(mask << start);
+        field |= (byte)(clampedValue << start);
+    }
+
+    public static sbyte GetSByteValue(ref readonly sbyte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (sbyte)((1 << length) - 1);
+
+        return (sbyte)((field >> start) & mask);
+    }
+
+    public static void SetSByteValue(ref sbyte field, Range range, sbyte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (sbyte)((1 << length) - 1);
+        var clampedValue = (sbyte)(value & mask);
+
+        field &= (sbyte)~(mask << start);
+        field |= (sbyte)(clampedValue << start);
+    }
+
+    public static sbyte GetSByteValue(ref readonly short field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (sbyte)((1 << length) - 1);
+
+        return (sbyte)((field >> start) & mask);
+    }
+
+    public static void SetSByteValue(ref short field, Range range, sbyte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (short)((1 << length) - 1);
+        var clampedValue = (short)(value & mask);
+
+        field &= (short)~(mask << start);
+        field |= (short)(clampedValue << start);
+    }
+
+    public static sbyte GetSByteValue(ref readonly ushort field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (sbyte)((1 << length) - 1);
+
+        return (sbyte)((field >> start) & mask);
+    }
+
+    public static void SetSByteValue(ref ushort field, Range range, sbyte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (ushort)((1 << length) - 1);
+        var clampedValue = (ushort)(value & mask);
+
+        field &= (ushort)~(mask << start);
+        field |= (ushort)(clampedValue << start);
+    }
+
+    public static sbyte GetSByteValue(ref readonly int field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (sbyte)((1 << length) - 1);
+
+        return (sbyte)((field >> start) & mask);
+    }
+
+    public static void SetSByteValue(ref int field, Range range, sbyte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (1 << length) - 1;
+        var clampedValue = (value & mask);
+
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static sbyte GetSByteValue(ref readonly uint field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (sbyte)((1U << length) - 1);
+
+        return (sbyte)((field >> start) & mask);
+    }
+
+    public static void SetSByteValue(ref uint field, Range range, sbyte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (1U << length) - 1;
+        var clampedValue = (uint)(value & mask);
+
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static sbyte GetSByteValue(ref readonly long field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (sbyte)((1L << length) - 1);
+
+        return (sbyte)((field >> start) & mask);
+    }
+
+    public static void SetSByteValue(ref long field, Range range, sbyte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = ((1L << length) - 1);
+        var clampedValue = (value & mask);
+
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static sbyte GetSByteValue(ref readonly ulong field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (1UL << length) - 1;
+
+        return (sbyte)((field >> start) & mask);
+    }
+
+    public static void SetSByteValue(ref ulong field, Range range, sbyte value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+
+        var mask = (1UL << length) - 1;
+        var clampedValue = ((ulong)value & mask);
+
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+}

--- a/PropertyBitPack/BitFieldUtils.Short.cs
+++ b/PropertyBitPack/BitFieldUtils.Short.cs
@@ -1,0 +1,203 @@
+﻿using CommunityToolkit.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PropertyBitPack;
+
+public static partial class BitFieldUtils
+{
+    public static short GetShortValue(ref readonly byte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (short)((1U << length) - 1);
+        return (short)((field >> start) & mask);
+    }
+
+    public static void SetShortValue(ref byte field, Range range, short value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (byte)((1 << length) - 1);
+        var clampedValue = (short)(value & mask);
+        field &= (byte)~(mask << start);
+        field |= (byte)(clampedValue << start);
+    }
+
+    public static short GetShortValue(ref readonly sbyte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (short)((1 << length) - 1);
+        return (short)((field >> start) & mask);
+    }
+
+    public static void SetShortValue(ref sbyte field, Range range, short value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (sbyte)((1 << length) - 1);
+        var clampedValue = (sbyte)(value & mask);
+        field &= (sbyte)~(mask << start);
+        field |= (sbyte)(clampedValue << start);
+    }
+
+    public static short GetShortValue(ref readonly short field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (short)((1U << length) - 1);
+        return (short)((field >> start) & mask);
+    }
+
+    public static void SetShortValue(ref short field, Range range, short value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (short)((1U << length) - 1);
+        var clampedValue = (short)(value & mask);
+        field &= (short)~(mask << start);
+        field |= (short)(clampedValue << start);
+    }
+
+    public static short GetShortValue(ref readonly ushort field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (short)((1U << length) - 1);
+        return (short)((field >> start) & mask);
+    }
+
+    public static void SetShortValue(ref ushort field, Range range, short value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (ushort)((1U << length) - 1);
+        var clampedValue = (ushort)(value & mask);
+        field &= (ushort)~(mask << start);
+        field |= (ushort)(clampedValue << start);
+    }
+
+    public static short GetShortValue(ref readonly int field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (short)((1U << length) - 1);
+        return (short)((field >> start) & mask);
+    }
+
+    public static void SetShortValue(ref int field, Range range, short value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1 << length) - 1;
+        var clampedValue = value & mask;
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static short GetShortValue(ref readonly uint field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1U << length) - 1;
+        return (short)((field >> start) & mask);
+    }
+
+    public static void SetShortValue(ref uint field, Range range, short value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1U << length) - 1;
+        var clampedValue = (uint)(value & mask);
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static short GetShortValue(ref readonly long field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1L << length) - 1;
+        return (short)((field >> start) & mask);
+    }
+
+    public static void SetShortValue(ref long field, Range range, short value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1L << length) - 1;
+        var clampedValue = value & mask;
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static short GetShortValue(ref readonly ulong field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1UL << length) - 1;
+        return (short)((field >> start) & mask);
+    }
+
+    public static void SetShortValue(ref ulong field, Range range, short value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1UL << length) - 1;
+        var clampedValue = ((ulong)value & mask);
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+}

--- a/PropertyBitPack/BitFieldUtils.UInt.cs
+++ b/PropertyBitPack/BitFieldUtils.UInt.cs
@@ -1,0 +1,203 @@
+﻿using CommunityToolkit.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PropertyBitPack;
+
+public static partial class BitFieldUtils
+{
+    public static uint GetUIntValue(ref readonly byte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (uint)((1U << length) - 1);
+        return (uint)((field >> start) & mask);
+    }
+
+    public static void SetUIntValue(ref byte field, Range range, uint value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (byte)((1 << length) - 1);
+        var clampedValue = (byte)(value & mask);
+        field &= (byte)~(mask << start);
+        field |= (byte)(clampedValue << start);
+    }
+
+    public static uint GetUIntValue(ref readonly sbyte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (uint)((1 << length) - 1);
+        return (uint)((field >> start) & mask);
+    }
+
+    public static void SetUIntValue(ref sbyte field, Range range, uint value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (sbyte)((1 << length) - 1);
+        var clampedValue = (uint)(value & (uint)mask);
+        field &= (sbyte)~(mask << start);
+        field |= (sbyte)(clampedValue << start);
+    }
+
+    public static uint GetUIntValue(ref readonly short field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (uint)((1U << length) - 1);
+        return (uint)((field >> start) & mask);
+    }
+
+    public static void SetUIntValue(ref short field, Range range, uint value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (short)((1U << length) - 1);
+        var clampedValue = (uint)(value & mask);
+        field &= (short)~(mask << start);
+        field |= (short)(clampedValue << start);
+    }
+
+    public static uint GetUIntValue(ref readonly ushort field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (uint)((1U << length) - 1);
+        return (uint)((field >> start) & mask);
+    }
+
+    public static void SetUIntValue(ref ushort field, Range range, uint value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (ushort)((1U << length) - 1);
+        var clampedValue = value & mask;
+        field &= (ushort)~(mask << start);
+        field |= (ushort)(clampedValue << start);
+    }
+
+    public static uint GetUIntValue(ref readonly int field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (uint)((1U << length) - 1);
+        return (uint)((field >> start) & mask);
+    }
+
+    public static void SetUIntValue(ref int field, Range range, uint value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1 << length) - 1;
+        var clampedValue = value & (uint)mask;
+        field &= ~(mask << start);
+        field |= (int)(clampedValue << start);
+    }
+
+    public static uint GetUIntValue(ref readonly uint field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1U << length) - 1;
+        return (uint)((field >> start) & mask);
+    }
+
+    public static void SetUIntValue(ref uint field, Range range, uint value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1U << length) - 1;
+        var clampedValue = value & mask;
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static uint GetUIntValue(ref readonly long field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1L << length) - 1;
+        return (uint)((field >> start) & mask);
+    }
+
+    public static void SetUIntValue(ref long field, Range range, uint value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1L << length) - 1;
+        var clampedValue = value & (uint)mask;
+        field &= ~(mask << start);
+        field |= ((long)clampedValue << start);
+    }
+
+    public static uint GetUIntValue(ref readonly ulong field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1UL << length) - 1;
+        return (uint)((field >> start) & mask);
+    }
+
+    public static void SetUIntValue(ref ulong field, Range range, uint value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (1UL << length) - 1;
+        var clampedValue = value & (uint)mask;
+        field &= ~(mask << start);
+        field |= ((ulong)clampedValue << start);
+    }
+}

--- a/PropertyBitPack/BitFieldUtils.ULong.cs
+++ b/PropertyBitPack/BitFieldUtils.ULong.cs
@@ -1,0 +1,198 @@
+﻿using CommunityToolkit.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PropertyBitPack;
+public static partial class BitFieldUtils
+{
+    public static ulong GetULongValue(ref readonly byte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (length == 8) ? ~0UL : ((1UL << length) - 1);
+        return (((ulong)field) >> start) & mask;
+    }
+
+    public static void SetULongValue(ref byte field, Range range, ulong value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (length == 8) ? ~0UL : ((1UL << length) - 1);
+        var clampedValue = value & mask;
+        field = (byte)(((ulong)field & ~(mask << start)) | (clampedValue << start));
+    }
+
+    public static ulong GetULongValue(ref readonly sbyte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (length == 8) ? ~0UL : ((1UL << length) - 1);
+        // Treat sbyte as unsigned 8-bit value.
+        return (((ulong)(byte)field) >> start) & mask;
+    }
+
+    public static void SetULongValue(ref sbyte field, Range range, ulong value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (length == 8) ? ~0UL : ((1UL << length) - 1);
+        var clampedValue = value & mask;
+        // Update sbyte by treating it as unsigned.
+        field = (sbyte)(((ulong)(byte)field & ~(mask << start)) | (clampedValue << start));
+    }
+
+    public static ulong GetULongValue(ref readonly short field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (length == 16) ? ~0UL : ((1UL << length) - 1);
+        // Treat short as unsigned 16-bit.
+        return (((ulong)(ushort)field) >> start) & mask;
+    }
+
+    public static void SetULongValue(ref short field, Range range, ulong value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (length == 16) ? ~0UL : ((1UL << length) - 1);
+        var clampedValue = value & mask;
+        field = (short)(((ulong)(ushort)field & ~(mask << start)) | (clampedValue << start));
+    }
+
+    public static ulong GetULongValue(ref readonly ushort field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (length == 16) ? ~0UL : ((1UL << length) - 1);
+        return (((ulong)field) >> start) & mask;
+    }
+
+    public static void SetULongValue(ref ushort field, Range range, ulong value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (length == 16) ? ~0UL : ((1UL << length) - 1);
+        var clampedValue = value & mask;
+        field = (ushort)(((ulong)field & ~(mask << start)) | (clampedValue << start));
+    }
+
+    public static ulong GetULongValue(ref readonly int field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (length == 32) ? ~0UL : ((1UL << length) - 1);
+        // Treat int as unsigned 32-bit.
+        return (((ulong)(uint)field) >> start) & mask;
+    }
+
+    public static void SetULongValue(ref int field, Range range, ulong value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (length == 32) ? ~0UL : ((1UL << length) - 1);
+        var clampedValue = value & mask;
+        field = (int)(((ulong)(uint)field & ~(mask << start)) | (clampedValue << start));
+    }
+
+    public static ulong GetULongValue(ref readonly uint field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (length == 32) ? ~0UL : ((1UL << length) - 1);
+        return (((ulong)field) >> start) & mask;
+    }
+
+    public static void SetULongValue(ref uint field, Range range, ulong value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 32)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 32 bits.");
+        }
+        var mask = (length == 32) ? ~0UL : ((1UL << length) - 1);
+        var clampedValue = value & mask;
+        field = (uint)(((ulong)field & ~(mask << start)) | (clampedValue << start));
+    }
+
+    public static ulong GetULongValue(ref readonly long field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 64)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 64 bits.");
+        }
+        var mask = (length == 64) ? ~0UL : ((1UL << length) - 1);
+        return (((ulong)field) >> start) & mask;
+    }
+
+    public static void SetULongValue(ref long field, Range range, ulong value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 64)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 64 bits.");
+        }
+        var mask = (length == 64) ? ~0UL : ((1UL << length) - 1);
+        var clampedValue = value & mask;
+        field = (long)(((ulong)field & ~(mask << start)) | (clampedValue << start));
+    }
+
+    public static ulong GetULongValue(ref readonly ulong field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 64)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 64 bits.");
+        }
+        var mask = (length == 64) ? ~0UL : ((1UL << length) - 1);
+        return (field >> start) & mask;
+    }
+
+    public static void SetULongValue(ref ulong field, Range range, ulong value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 64)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 64 bits.");
+        }
+        var mask = (length == 64) ? ~0UL : ((1UL << length) - 1);
+        var clampedValue = value & mask;
+        field = (field & ~(mask << start)) | (clampedValue << start);
+    }
+}

--- a/PropertyBitPack/BitFieldUtils.UShort.cs
+++ b/PropertyBitPack/BitFieldUtils.UShort.cs
@@ -1,0 +1,203 @@
+﻿using CommunityToolkit.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PropertyBitPack;
+
+public static partial class BitFieldUtils
+{
+    public static ushort GetUShortValue(ref readonly byte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (ushort)((1U << length) - 1);
+        return (ushort)((field >> start) & mask);
+    }
+
+    public static void SetUShortValue(ref byte field, Range range, ushort value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (byte)((1 << length) - 1);
+        var clampedValue = (ushort)(value & mask);
+        field &= (byte)~(mask << start);
+        field |= (byte)(clampedValue << start);
+    }
+
+    public static ushort GetUShortValue(ref readonly sbyte field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (ushort)((1 << length) - 1);
+        return (ushort)((field >> start) & mask);
+    }
+
+    public static void SetUShortValue(ref sbyte field, Range range, ushort value)
+    {
+        (var start, var length) = GetRangeBounds(range, 8);
+        if (length <= 0 || length > 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 8 bits.");
+        }
+        var mask = (sbyte)((1 << length) - 1);
+        var clampedValue = (ushort)(value & (ushort)mask);
+        field &= (sbyte)~(mask << start);
+        field |= (sbyte)(clampedValue << start);
+    }
+
+    public static ushort GetUShortValue(ref readonly short field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (ushort)((1U << length) - 1);
+        return (ushort)((field >> start) & mask);
+    }
+
+    public static void SetUShortValue(ref short field, Range range, ushort value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (short)((1U << length) - 1);
+        var clampedValue = (ushort)(value & mask);
+        field &= (short)~(mask << start);
+        field |= (short)(clampedValue << start);
+    }
+
+    public static ushort GetUShortValue(ref readonly ushort field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (ushort)((1U << length) - 1);
+        return (ushort)((field >> start) & mask);
+    }
+
+    public static void SetUShortValue(ref ushort field, Range range, ushort value)
+    {
+        (var start, var length) = GetRangeBounds(range, 16);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (ushort)((1U << length) - 1);
+        var clampedValue = (ushort)(value & mask);
+        field &= (ushort)~(mask << start);
+        field |= (ushort)(clampedValue << start);
+    }
+
+    public static ushort GetUShortValue(ref readonly int field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (ushort)((1U << length) - 1);
+        return (ushort)((field >> start) & mask);
+    }
+
+    public static void SetUShortValue(ref int field, Range range, ushort value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1 << length) - 1;
+        var clampedValue = (ushort)(value & mask);
+        field &= ~(mask << start);
+        field |= (clampedValue << start);
+    }
+
+    public static ushort GetUShortValue(ref readonly uint field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1U << length) - 1;
+        return (ushort)((field >> start) & mask);
+    }
+
+    public static void SetUShortValue(ref uint field, Range range, ushort value)
+    {
+        (var start, var length) = GetRangeBounds(range, 32);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1U << length) - 1;
+        var clampedValue = (ushort)(value & mask);
+        field &= ~(mask << start);
+        field |= (uint)(clampedValue << start);
+    }
+
+    public static ushort GetUShortValue(ref readonly long field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1L << length) - 1;
+        return (ushort)((field >> start) & mask);
+    }
+
+    public static void SetUShortValue(ref long field, Range range, ushort value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1L << length) - 1;
+        var clampedValue = (ushort)(value & mask);
+        field &= ~(mask << start);
+        field |= ((long)clampedValue << start);
+    }
+
+    public static ushort GetUShortValue(ref readonly ulong field, Range range)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1UL << length) - 1;
+        return (ushort)((field >> start) & mask);
+    }
+
+    public static void SetUShortValue(ref ulong field, Range range, ushort value)
+    {
+        (var start, var length) = GetRangeBounds(range, 64);
+        if (length <= 0 || length > 16)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "The bit range must be between 1 and 16 bits.");
+        }
+        var mask = (1UL << length) - 1;
+        var clampedValue = (ushort)(value & mask);
+        field &= ~(mask << start);
+        field |= ((ulong)clampedValue << start);
+    }
+}

--- a/PropertyBitPack/BitFieldUtils.cs
+++ b/PropertyBitPack/BitFieldUtils.cs
@@ -1,0 +1,23 @@
+﻿using CommunityToolkit.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PropertyBitPack;
+public static partial class BitFieldUtils
+{
+    private static (int start, int length) GetRangeBounds(Range range, int maxBits)
+    {
+        var start = range.Start.IsFromEnd ? maxBits - range.Start.Value : range.Start.Value;
+        var end = range.End.IsFromEnd ? maxBits - range.End.Value : range.End.Value;
+
+        if (start < 0 || end > maxBits || start >= end)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(range), range, "Invalid bit range.");
+        }
+
+        return (start, end - start);
+    }
+}

--- a/PropertyBitPack/PropertyBitPack.csproj
+++ b/PropertyBitPack/PropertyBitPack.csproj
@@ -39,4 +39,8 @@
     <Content Include="icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.4.0" />
+  </ItemGroup>
+
 </Project>

--- a/PropertyBitPackDocs/_pages/bit-field-utils.md
+++ b/PropertyBitPackDocs/_pages/bit-field-utils.md
@@ -1,0 +1,71 @@
+﻿---
+title: BitFieldUtils
+---
+
+**BitFieldUtils** is a static utility class included in PropertyBitPack that provides methods to manipulate bit‑packed data across various numeric types. These methods let you extract and update bit ranges within underlying numeric fields, ensuring efficient and collision‑free storage of multiple properties.
+
+## Key Features
+
+- **Multi-Type Support:**  
+  Methods are provided for types such as `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, and `ulong`.
+
+- **Flexible Range Specification:**  
+  All methods accept a C\# `Range` parameter, allowing you to define bit ranges using standard range syntax (e.g. `start..end`, `start..`, `..end`, and caret notation like `^start`).
+
+- **Collision Prevention:**  
+  By operating on specific bit ranges, BitFieldUtils ensures that modifying one property does not interfere with another within the same underlying field.
+
+## Example Usage
+
+### Getting and Setting a Boolean Value
+```csharp
+byte field = 0;
+int bitIndex = 3;
+BitFieldUtils.SetBoolValue(ref field, bitIndex, true);
+bool result = BitFieldUtils.GetBoolValue(ref field, bitIndex);
+Console.WriteLine(result); // Outputs: True
+```
+
+### Manipulating a Numeric Value in a Specified Bit Range
+```csharp
+int field = 0;
+var range = 10..20; // 10-bit range within a 32-bit field
+int valueToSet = 0b1010101010; // Binary literal for a 10-bit value (682 in decimal)
+BitFieldUtils.SetIntValue(ref field, range, valueToSet);
+int extractedValue = BitFieldUtils.GetIntValue(ref field, range);
+Console.WriteLine(extractedValue); // Outputs: 682
+```
+
+## Advanced Usage
+
+### Using Range Operators with Caret Notation
+
+You can use the caret operator (`^`) to specify bit ranges from the end of the field:
+```csharp
+// For an 8-bit field:
+byte field = 0;
+BitFieldUtils.SetByteValue(ref field, ^3..^1, 0b10); // Sets a 2-bit range (from index 5 to 7)
+byte value = BitFieldUtils.GetByteValue(ref field, ^3..^1);
+Console.WriteLine(Convert.ToString(value, 2)); // Outputs the 2-bit value in binary
+```
+
+### Combining Multiple Values in a Single Field (Collision Prevention)
+
+BitFieldUtils methods support partitioning a field into multiple segments:
+```csharp
+// Partition a byte into three segments: bits 0–2, 3–5, and 6–7.
+byte field = 0;
+BitFieldUtils.SetByteValue(ref field, 0..3, 0b101);  // First 3 bits
+BitFieldUtils.SetByteValue(ref field, 3..6, 0b011);  // Next 3 bits
+BitFieldUtils.SetByteValue(ref field, 6..8, 0b10);   // Last 2 bits
+
+// Retrieve each value separately.
+byte firstSegment = BitFieldUtils.GetByteValue(ref field, 0..3);
+byte secondSegment = BitFieldUtils.GetByteValue(ref field, 3..6);
+byte thirdSegment = BitFieldUtils.GetByteValue(ref field, 6..8);
+Console.WriteLine($"{firstSegment}, {secondSegment}, {thirdSegment}"); // Outputs: 5, 3, 2
+```
+
+# Conclusion
+
+BitFieldUtils provides a powerful and flexible API for low‑level bit manipulation. Whether you need to pack multiple boolean values into a single byte or split a 64‑bit field into custom‑sized segments, BitFieldUtils ensures efficient, safe, and collision‑free operations.

--- a/PropertyBitPackDocs/_pages/sidebar.json
+++ b/PropertyBitPackDocs/_pages/sidebar.json
@@ -34,6 +34,10 @@
     "link": "PropertyBitPack/read-only-extended-bit-field-attribute"
   },
   {
+    "text": "BitFieldUtils",
+    "link": "PropertyBitPack/bit-field-utils"
+  },
+  {
     "text": "Diagnostic",
     "link": "PropertyBitPack/diagnostics"
   }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ PropertyBitPack is a Roslyn source generator that simplifies defining and managi
   - [ExtendedBitFieldAttribute](#extendedbitfieldattribute)
   - [Define Read-Only Bit-Packed Properties](#define-read-only-bit-packed-properties)
   - [ReadOnlyExtendedBitField](#readonlyextendedbitfield)
+  - [BitFieldUtils Overview](#bitfieldutils-overview)
 
 ## Installation
 
@@ -785,3 +786,39 @@ partial class SimpleReadOnlyExample
 ### ReadOnlyExtendedBitField
 
 `ReadOnlyExtendedBitFieldAttribute` provides functionality similar to `ReadOnlyBitFieldAttribute`, but for extended bit field scenarios.
+
+
+## BitFieldUtils Overview
+
+The **BitFieldUtils** class is a static helper that provides methods for extracting and updating bit‑packed data across various numeric types. These methods include:
+
+- **Boolean Values:**  
+  - `GetBoolValue` and `SetBoolValue` work on individual bits.
+
+- **Numeric Values:**  
+  - `GetByteValue` and `SetByteValue` for `byte`.  
+  - `GetSByteValue` and `SetSByteValue` for `sbyte`.  
+  - `GetShortValue` and `SetShortValue` for `short`.  
+  - `GetUShortValue` and `SetUShortValue` for `ushort`.  
+  - `GetIntValue` and `SetIntValue` for `int`.  
+  - `GetUIntValue` and `SetUIntValue` for `uint`.  
+  - `GetLongValue` and `SetLongValue` for `long`.  
+  - `GetULongValue` and `SetULongValue` for `ulong`.
+
+All these methods accept a C\# `Range` parameter so you can specify the bit range to work with using the full range syntax (e.g. `start..end`, `..end`, `start..`, `^start..^end`, etc.).
+
+## Example Usage
+
+```csharp
+// Setting and getting a boolean value in a byte:
+byte byteField = 0;
+int bitIndex = 3;
+BitFieldUtils.SetBoolValue(ref byteField, bitIndex, true);
+bool boolResult = BitFieldUtils.GetBoolValue(ref byteField, bitIndex);
+Console.WriteLine(boolResult); // Outputs: True
+
+// Extracting a 3-bit value from a byte field using a range:
+byte fieldValue = 0b10110100;
+byte extractedValue = BitFieldUtils.GetByteValue(ref fieldValue, 2..5);
+Console.WriteLine(Convert.ToString(extractedValue, 2)); // Outputs the 3-bit value in binary
+```


### PR DESCRIPTION
## What does the pull request do?  
This pull request introduces new unit tests for `BitFieldUtils` and implements methods for setting and getting boolean values in various integer types.  

## What is the current behavior?  
- `BitFieldUtils` lacked dedicated methods for handling boolean values in different integer types.  
- No unit tests were available to validate bitwise operations for boolean values.  

## What is the updated/expected behavior with this PR?  
- **New methods added**:  
  - `GetBoolValue` and `SetBoolValue` implemented for `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, and `ulong`.  
  - Methods validate bit index ranges to prevent out-of-bounds access.  

- **Unit tests introduced**:  
  - Validates `GetBoolValue` and `SetBoolValue` for various integer types.  
  - Covers single-bit, multi-bit, and range-based operations.  

## How was the solution implemented?  

### **Unit Tests Addition**  
- **[`BitFieldUtilsTest.cs`](diffhunk://#diff-bc44d513add94a6ef5ed71aa8706033c47ceb99d73f5b400832e364bb28fe518R1-R346)**  
  - Added test cases for `Set` and `Get` methods across multiple integer types.  

### **Boolean Value Handling Methods**  
- **[`BitFieldUtils.Bool.cs`](diffhunk://#diff-3a44f7492f3a95efd373bfeb877a3ced1a59e25060b2c3829c32ae3838c7c09dR1-R230)**  
  - Implemented `GetBoolValue` and `SetBoolValue` for multiple integer types.  
  - Added validation to prevent out-of-bounds bit access.  

## Checklist  

- [x] Added unit tests.  
- [ ] Updated XML documentation where applicable.  
- [x] Followed the coding style and formatting rules.  
- [x] All CI checks passed.  

## Breaking changes  
None.  

## Obsoletions / Deprecations  
None.  

## Fixed issues  
None.  
